### PR TITLE
added init values, removing compiler ambiguity

### DIFF
--- a/020_playerMovement/Sources/Player.hx
+++ b/020_playerMovement/Sources/Player.hx
@@ -15,7 +15,8 @@ class Player {
   public var down:Bool;
   
   public function new(){
-    
+    this.x = 0;
+    this.y = 0;
   }
 
   public function update(){


### PR DESCRIPTION
player.x and player.y could have been initialized to 0 (if lucky) or null (depending on the compiler version or platform target I guess ?). Meaning the player could not have been properly rendered.